### PR TITLE
Adopt npm OIDC trusted publishing (Node 22 in CI/publish)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Node 12 
-      uses: actions/setup-node@v2-beta
+    - uses: actions/checkout@v4
+    - name: Setup Node 22
+      uses: actions/setup-node@v4
       with:
-        node-version: '12'
+        node-version: '22.14.0'
     - name: Install packages
       run: npm install
     - name: Run test

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -19,7 +19,7 @@ jobs:
         node-version: 22.14.0
         registry-url: 'https://registry.npmjs.org'
     - name: Upgrade npm for OIDC support
-      run: npm install -g npm@latest # trusted publishing needs npm >= 11.5.1
+      run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
     - run: npm install
     - run: npm run build
     - run: npm publish # authenticates via OIDC, no token needed

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -11,15 +11,15 @@ jobs:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22.14.0
-        registry-url: 'https://registry.npmjs.org'
-    - name: Upgrade npm for OIDC support
-      run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
-    - run: npm install
-    - run: npm run build
-    - run: npm publish # authenticates via OIDC, no token needed
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
+      - run: npm install
+      - run: npm run build
+      - run: npm publish # authenticates via OIDC, no token needed

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -3,19 +3,23 @@ on:
   push:
     branches:
       - master # Change this to your default branch
+permissions:
+  id-token: write # Required for npm OIDC trusted publishing
+  contents: read
 jobs:
   npm-publish:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Node.js
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v4
       with:
-        node-version: 12.0.0
+        node-version: 22.14.0
+        registry-url: 'https://registry.npmjs.org'
+    - name: Upgrade npm for OIDC support
+      run: npm install -g npm@latest # trusted publishing needs npm >= 11.5.1
     - run: npm install
     - run: npm run build
-    - uses: JS-DevTools/npm-publish@v1
-      with:
-        token: ${{ secrets.NPM_AUTH_TOKEN }}
+    - run: npm publish # authenticates via OIDC, no token needed

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -11,15 +11,15 @@ jobs:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.14.0
-          registry-url: 'https://registry.npmjs.org'
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
-      - run: npm install
-      - run: npm run build
-      - run: npm publish # authenticates via OIDC, no token needed
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.14.0
+        registry-url: 'https://registry.npmjs.org'
+    - name: Upgrade npm for OIDC support
+      run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
+    - run: npm install
+    - run: npm run build
+    - run: npm publish # authenticates via OIDC, no token needed


### PR DESCRIPTION
## What

- Switch `npm-publish.yaml` to **npm OIDC trusted publishing** — `npm publish` now authenticates via GitHub OIDC instead of a stored `NPM_AUTH_TOKEN`.
- Add the required `id-token: write` / `contents: read` permissions and upgrade npm to a version that supports OIDC.
- Bump CI and publish workflows to **Node 22.14** and refresh stale actions (`checkout@v2 → v4`, `setup-node@v2-beta → v4`).

## Why Node 22

Trusted publishing needs **npm ≥ 11.5.1**, which only ships with **Node ≥ 22.14**. The Node bump exists solely to make that npm version available on the build/publish runner.

## Why this does NOT affect the package

The Node version that *builds* the package has no bearing on what consumers get:

- TypeScript compiles to **es2018**, so the emitted JS runs on Node 12+.
- Every runtime dependency already supports old Node (`@postman/grpc-js` ≥12.10, `@postman/protobufjs` ≥12.0, `google-protobuf` unconstrained).
- The published artifact and its runtime behavior are **identical** regardless of the builder's Node version.

Because of this, **no `engines` field was added** — that would falsely warn consumers on Node < 22 that they need Node 22 to use the package, when the real floor is ~Node 12.

## Action required before merge (npm-side)
The workflow file `npm-publish.yaml` has been added in NPM config. This enables publishing without the NPM token.

## Verification

Build, lint, and the full test suite pass on Node 22.16 locally.

Generated with [Claude Code](https://claude.com/claude-code)