### PR TITLE
fix(ci): publish via canonical security-npm-publish workflow + wire npm read token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,12 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '22.14.0'
+        registry-url: 'https://registry.npmjs.org'
     - name: Install packages
       run: npm install
+      env:
+        # read auth so the private @postman/* deps resolve (setup-node writes the .npmrc)
+        NODE_AUTH_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}
     - name: Run test
       run: npm test
     - name: Coverage report

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,25 +1,32 @@
+# npm Trusted Publisher is bound to this repo + this workflow FILENAME
+# (postmanlabs/grpc-reflection-js -> npm-publish.yaml, permission: npm publish).
+# Do NOT rename this file, or the OIDC claim stops matching and trusted publishing breaks.
 name: NPM Publish
+
 on:
   push:
-    branches:
-      - master # Change this to your default branch
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.1.2-postman.11)'
+        required: true
+        type: string
+
 permissions:
-  id-token: write # Required for npm OIDC trusted publishing
   contents: read
+  id-token: write # required for npm OIDC trusted publishing
+
 jobs:
-  npm-publish:
-    name: npm-publish
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22.14.0
-        registry-url: 'https://registry.npmjs.org'
-    - name: Upgrade npm for OIDC support
-      run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
-    - run: npm install
-    - run: npm run build
-    - run: npm publish # authenticates via OIDC, no token needed
+  call-npm-release:
+    # Canonical, security-controlled publish flow. Installs deps authenticated
+    # with POSTMAN_NPM_TOKEN (so the private @postman/* deps resolve), then
+    # publishes via OIDC trusted publishing (no token on the publish step).
+    uses: postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml@main
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
+      node_version: '22'
+      skip_tests: true
+    secrets:
+      POSTMAN_NPM_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}


### PR DESCRIPTION
## Problem
The `NPM Publish` job fails at `npm install`, *before* it ever reaches `npm publish`:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@postman/protobufjs/-/protobufjs-7.5.4-postman.2.tgz
```

`@postman/protobufjs` is a **private** dependency. The workflow set `registry-url` but never fed a read token, so `npm install` ran **anonymously** and 404'd (npm returns 404, not 401, for private packages you can't see). OIDC trusted publishing only authorizes *publishing the output package* — it does **not** grant read access to private dependencies. So the OIDC setup was correct but incomplete.

## This PR (recommended approach)
- **`npm-publish.yaml`** now delegates to the canonical `postmanlabs/gh-security-scan-workflow/.github/workflows/security-npm-publish.yml`, which installs authenticated with `POSTMAN_NPM_TOKEN` (private deps resolve) and then publishes via **OIDC** (no token on the publish step). Same pattern platform-heimdal uses.
- **Filename kept as `npm-publish.yaml`** on purpose — the npm Trusted Publisher config is bound to `postmanlabs/grpc-reflection-js` + this exact filename, so renaming it would break OIDC matching.
- **Trigger moved to version tags (`v*`)** + `workflow_dispatch`, replacing the publish-on-every-master-push behavior.
- **`ci.yaml`** gets the same read-token wiring so PR/CI installs also stop 404ing.

## Notes
- The reusable is referenced at `@main` to match the heimdal setup; pinning to a tag/SHA is the stricter supply-chain choice if you prefer.
- Alternative, more minimal approach in the sibling PR (keeps the bespoke publish steps).