### PR TITLE
fix(ci): wire POSTMAN_NPM_TOKEN for private-dep install (keep bespoke publish)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,12 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '22.14.0'
+        registry-url: 'https://registry.npmjs.org'
     - name: Install packages
       run: npm install
+      env:
+        # read auth so the private @postman/* deps resolve (setup-node writes the .npmrc)
+        NODE_AUTH_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}
     - name: Run test
       run: npm test
     - name: Coverage report

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -21,5 +21,9 @@ jobs:
     - name: Upgrade npm for OIDC support
       run: npm install -g npm@11.5.1 # trusted publishing needs npm >= 11.5.1
     - run: npm install
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }} # read auth for private @postman/* deps
     - run: npm run build
-    - run: npm publish # authenticates via OIDC, no token needed
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.POSTMAN_NPM_TOKEN }}
+    - run: npm publish # OIDC trusted publishing — no token on this step (token would bypass OIDC)


### PR DESCRIPTION
## Problem
Same root cause as the sibling PR: `NPM Publish` fails at `npm install` because the **private** dep `@postman/protobufjs` resolves anonymously and 404s. OIDC authorizes *publishing the output*, not *reading private dependencies*.

## This PR (minimal alternative)
- **`npm-publish.yaml`**: add `NODE_AUTH_TOKEN` (`POSTMAN_NPM_TOKEN`) to the **install + build** steps only. The **publish step stays token-free** so OIDC trusted publishing is used (a token there would bypass OIDC). The setup-node placeholder token does not block OIDC.
- **Filename unchanged** so the Trusted Publisher config keeps matching.
- **`ci.yaml`**: same read-auth wiring for PR/CI installs.

## Notes
- **Pre-existing, not addressed here:** this workflow still triggers on every push to `master`, so after the first publish it will attempt to republish the same `package.json` version and fail on a version conflict. The sibling (canonical) PR fixes that by moving to tag-triggered publishes.
- Alternative, fuller approach in the sibling PR (adopts the shared security-npm-publish workflow).